### PR TITLE
M3 575 filter depricated images

### DIFF
--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -5,6 +5,7 @@ export type ImageStatus =
   | 'pending_upload';
 
 export interface Image {
+  eol: string | null;
   id: string;
   label: string;
   description: string | null;

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -1,0 +1,41 @@
+import { imagesToGroupedItems } from './ImageSelect';
+import { imageFactory } from 'src/factories';
+
+describe('imagesToGroupedItems', () => {
+  it('should filter deprecated images when eol date is beyond 6 months ', () => {
+    const images = [
+      ...imageFactory.buildList(2, {
+        label: 'Debian 9',
+        deprecated: true,
+        created: '2017-06-16T20:02:29',
+        eol: '2022-01-01T14:05:30',
+      }),
+      ...imageFactory.buildList(2, {
+        label: 'Slackware 14.1',
+        deprecated: true,
+        created: '2022-10-20T14:05:30',
+        eol: null,
+      }),
+    ];
+    const expected = [
+      {
+        label: 'My Images',
+        options: [
+          {
+            created: '2022-10-20T14:05:30',
+            label: 'Slackware 14.1 (Deprecated)',
+            value: 'private/2',
+            className: 'fl-tux',
+          },
+          {
+            created: '2022-10-20T14:05:30',
+            label: 'Slackware 14.1 (Deprecated)',
+            value: 'private/3',
+            className: 'fl-tux',
+          },
+        ],
+      },
+    ];
+    expect(imagesToGroupedItems(images)).toStrictEqual(expected);
+  });
+});

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -1,5 +1,6 @@
 import { Image } from '@linode/api-v4/lib/images';
 import produce from 'immer';
+import { DateTime } from 'luxon';
 import { equals, groupBy } from 'ramda';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
@@ -16,6 +17,7 @@ import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOption
 import { distroIcons } from './icons';
 import ImageOption from './ImageOption';
 
+const maxEOLFilter = 6;
 export type Variant = 'public' | 'private' | 'all';
 
 interface ImageItem extends Item<string> {
@@ -85,6 +87,18 @@ export const imagesToGroupedItems = (images: Image[]) => {
         draft.push({
           label: thisGroup,
           options: group
+            .filter((thisImage) => {
+              const { deprecated, eol } = thisImage;
+              if (deprecated) {
+                const diff = DateTime.now().diff(
+                  DateTime.fromISO(eol),
+                  'months'
+                ).months;
+                return Number.isNaN(diff) || diff <= maxEOLFilter;
+              } else {
+                return true;
+              }
+            })
             .map((thisImage) => {
               const isDeprecated = thisImage.deprecated;
               const fullLabel =

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -91,7 +91,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
               const { deprecated, eol } = thisImage;
               if (deprecated) {
                 const diff = DateTime.now().diff(
-                  DateTime.fromISO(eol),
+                  DateTime.fromISO(eol!),
                   'months'
                 ).months;
                 return Number.isNaN(diff) || diff <= maxEOLFilter;

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -2,6 +2,7 @@ import * as Factory from 'factory.ts';
 import { Image } from '@linode/api-v4/lib/images/types';
 
 export const imageFactory = Factory.Sync.makeFactory<Image>({
+  eol: new Date().toISOString(),
   id: Factory.each((id) => `private/${id}`),
   label: Factory.each((i) => `image-${i}`),
   description: 'An image',


### PR DESCRIPTION
## Description 📝

This change automatically filters all deprecated images based on `eol` date past beyond `6` months. 

## Preview 📷
**Before**
![image](https://user-images.githubusercontent.com/119517080/205923284-5fee565b-f809-41eb-b396-72822e494cef.png)

**After** 
![image](https://user-images.githubusercontent.com/119517080/205921337-7fcd8f79-c025-4668-8a18-c05180106a9e.png)


## How to test 🧪

`yarn test components/ImageSelect/ImageSelect `

